### PR TITLE
Add before condition to Rails initializer

### DIFF
--- a/lib/mailgunner/railtie.rb
+++ b/lib/mailgunner/railtie.rb
@@ -1,6 +1,6 @@
 module Mailgunner
   class Railtie < Rails::Railtie
-    initializer 'mailgunner' do
+    initializer 'mailgunner', before: 'action_mailer.set_configs' do
       ActiveSupport.on_load(:action_mailer) do
         require 'mailgunner/delivery_method'
       end


### PR DESCRIPTION
I experienced an issue after deploying where `mailgun_settings` could not be found on `ActionMailer::Base`. After a while I realised that the only thing that could've happened, was that `add_delivery_method` hadn't been invoked by Mailgunner yet. So it had to be a loading issue, since Mailgunner checks whether `ActionMailer` has been loaded before invoking `add_delivery_method`.

This PR places Mailgunner's initializer right before `action_mailer.set_configs`. That way we know for sure that `ActionMailer` has been loaded.