### PR TITLE
Add instructions to configure Rails without ENV variables.

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,17 @@ the following line to `config/environments/production.rb`:
 config.action_mailer.delivery_method = :mailgun
 ````
 
+If for some reason you can't set the required ENV variables, you can configure Mailgunner
+through ActionMailer settings:
+
+```ruby
+config.action_mailer.mailgun_settings = {
+  domain: 'test.com'
+  api_key: 'your-api-key'
+}
+
+```
+
 Outside of Rails you can set `ActionMailer::Base.delivery_method` directly.
 
 


### PR DESCRIPTION
I think this will save some time to people who wants to configure Mailgunner but for some reason they can't use ENV variables.