### PR TITLE
Handle errored responses without a response body correctly

### DIFF
--- a/lib/mailgunner.rb
+++ b/lib/mailgunner.rb
@@ -347,7 +347,7 @@ module Mailgunner
     def json?(response)
       content_type = response['Content-Type']
 
-      content_type && content_type.split(';').first == 'application/json'
+      !response.body.empty? && content_type && content_type.split(';').first == 'application/json'
     end
 
     def request_uri(path, hash)


### PR DESCRIPTION
Some Mailgun error responses come back with the Content-Type set to application/json, but no actual response body. In those cases, mailgunner would blow up with a "JSON::ParserError: A JSON text must at least contain two octets!" rather than the correct `Mailgunner::Error` exception.